### PR TITLE
fix: error on empty charSequenceText.

### DIFF
--- a/app/src/main/java/com/github/jing332/tts_server_android/service/systts/SystemTtsService.kt
+++ b/app/src/main/java/com/github/jing332/tts_server_android/service/systts/SystemTtsService.kt
@@ -219,6 +219,12 @@ class SystemTtsService : TextToSpeechService(), TextToSpeechManager.Listener {
     private var mNotificationJob: Job? = null
 
     override fun onSynthesizeText(request: SynthesisRequest, callback: SynthesisCallback) {
+
+        if (request.charSequenceText?.isBlank() == true) {
+            callback.done()
+            return
+        }
+
         mNotificationJob?.cancel()
         reNewWakeLock()
         startForegroundService()

--- a/app/src/main/java/com/github/jing332/tts_server_android/service/systts/SystemTtsService.kt
+++ b/app/src/main/java/com/github/jing332/tts_server_android/service/systts/SystemTtsService.kt
@@ -220,7 +220,8 @@ class SystemTtsService : TextToSpeechService(), TextToSpeechManager.Listener {
 
     override fun onSynthesizeText(request: SynthesisRequest, callback: SynthesisCallback) {
 
-        if (request.charSequenceText?.isBlank() == true) {
+        if (request.charSequenceText == null ||
+            request.charSequenceText.isBlank()) {
             callback.done()
             return
         }


### PR DESCRIPTION
https://github.com/gedoor/legado/blob/f6c025d160f22a7d52adf754e1c311f20791c30b/app/src/main/java/io/legado/app/help/TTS.kt#L82
```kotlin
var result = tts.speak("", TextToSpeech.QUEUE_FLUSH, null, null)
```
在阅读app中使用时，都会在第一次触发NPE异常。
针对这种TTS合成请求，应该是不需要合成的，
按照要刷新队列的思路，应该直接判断为成功进行返回。